### PR TITLE
Increase tap to spin button size by 20%

### DIFF
--- a/index.html
+++ b/index.html
@@ -105,8 +105,8 @@
         --font-family: 'Poppins';
         --icon-w: 112px;
         --icon-h: 112px;
-        --spin-button-width: 34%;
-        --spin-button-max-width: 170px;
+        --spin-button-width: 40.8%;
+        --spin-button-max-width: 204px;
         --spin-button-aspect: 2019 / 657;
         --instructions-max-width: 580px;
       }


### PR DESCRIPTION
## Summary
- increase the spin button CSS custom properties so the tap-to-spin art renders 20% larger across all languages

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d43ecd5990832fba5c7a5e69ba8dc1