### PR TITLE
Align landing text with container top

### DIFF
--- a/index.html
+++ b/index.html
@@ -142,7 +142,7 @@
         justify-content: flex-start;
         align-items: center;
         text-align: center;
-        padding-top: min(2vh, 2%);
+        padding-top: 0;
         overflow: hidden;
         pointer-events: none;
         z-index: 21;
@@ -156,7 +156,7 @@
         align-items: center;
         justify-content: flex-start;
         text-align: center;
-        padding: 6% 7% 7%;
+        padding: 0 7% 7%;
         box-sizing: border-box;
         max-width: 100%;
         max-height: 100%;


### PR DESCRIPTION
## Summary
- remove extra top padding from the landing text container
- trim top padding from the inner intro text wrapper so copy aligns with the top of the board

## Testing
- not run (static CSS change)


------
https://chatgpt.com/codex/tasks/task_b_68d594b33ce0832f90ccc363da2999ff