### PR TITLE
Restyle landing hint to match orange button

### DIFF
--- a/index.html
+++ b/index.html
@@ -91,16 +91,25 @@
         left: 50%;
         transform: translateX(-50%);
         bottom: 7.5%;
-        padding: 0.4rem 0.8rem;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        padding: clamp(0.35rem, 1.2vw, 0.75rem)
+          clamp(0.85rem, 3.4vw, 1.8rem);
         border-radius: 999px;
-        background: rgba(255, 255, 255, 0.85);
-        color: #5c3b1e;
+        background: #e69c6a;
+        border: clamp(3px, 1vw, 6px) solid #fff2d9;
+        color: #fff2d9;
         font-family: 'SparkyStones', sans-serif;
-        font-size: clamp(14px, 2.6vw, 20px);
-        line-height: 1.2;
+        font-size: clamp(16px, 3vw, 24px);
+        line-height: 1.1;
         text-align: center;
-        letter-spacing: 0.3px;
-        box-shadow: 0 2px 6px rgba(0, 0, 0, 0.12);
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        text-shadow: 0 2px 0 rgba(159, 83, 36, 0.85);
+        box-shadow: 0 6px 0 rgba(159, 83, 36, 0.55),
+          0 10px 16px rgba(0, 0, 0, 0.16);
+        max-width: min(86%, 320px);
         opacity: 0;
         pointer-events: none;
       }
@@ -124,10 +133,14 @@
 
       @keyframes hint-pulse {
         from {
-          box-shadow: 0 2px 6px rgba(0, 0, 0, 0.12);
+          transform: translateX(-50%) translateY(0) scale(1);
+          box-shadow: 0 6px 0 rgba(159, 83, 36, 0.55),
+            0 10px 16px rgba(0, 0, 0, 0.16);
         }
         to {
-          box-shadow: 0 4px 10px rgba(0, 0, 0, 0.18);
+          transform: translateX(-50%) translateY(0) scale(1.04);
+          box-shadow: 0 8px 0 rgba(159, 83, 36, 0.6),
+            0 14px 22px rgba(0, 0, 0, 0.2);
         }
       }
 


### PR DESCRIPTION
## Summary
- restyle the landing hint banner to match the orange button color palette, typography, and drop shadow
- ensure the hint text stays uppercase, centered on the base, and scales responsively across viewports

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d5b53868b0832f94e3155a0b5e3d80