### PR TITLE
Adjust gender overlay colors

### DIFF
--- a/index.html
+++ b/index.html
@@ -1211,6 +1211,7 @@
         const isGirl = params.gender === "2";
         const isBoy = params.gender === "1";
         const defaultOverlayColor = "#f3ddbb";
+        const defaultGenderOverlayBg = "rgba(255, 255, 255, 0.6)";
         function setGenderState() {
           if (isBoy) {
             genderText.textContent = genderTranslations.boy;
@@ -1218,6 +1219,7 @@
             genderText.style.textShadow =
               "-2px -2px 0 #5c928c, 2px -2px 0 #5c928c, -2px 2px 0 #5c928c, 2px 2px 0 #5c928c";
             colorOverlay.style.backgroundColor = "#a4c9c4";
+            genderOverlay.style.background = "rgba(164, 201, 196, 0.75)";
             genderOverlay.setAttribute("data-gender", "boy");
           } else if (isGirl) {
             genderText.textContent = genderTranslations.girl;
@@ -1225,12 +1227,14 @@
             genderText.style.textShadow =
               "-2px -2px 0 #ef8d6d, 2px -2px 0 #ef8d6d, -2px 2px 0 #ef8d6d, 2px 2px 0 #ef8d6d";
             colorOverlay.style.backgroundColor = "#f7c4b4";
+            genderOverlay.style.background = "rgba(247, 196, 180, 0.75)";
             genderOverlay.setAttribute("data-gender", "girl");
           } else {
             genderText.textContent = "";
             genderText.style.color = "";
             genderText.style.textShadow = "";
             colorOverlay.style.backgroundColor = defaultOverlayColor;
+            genderOverlay.style.background = defaultGenderOverlayBg;
             genderOverlay.removeAttribute("data-gender");
           }
         }


### PR DESCRIPTION
## Summary
- tint the gender overlay background based on the selected gender to ensure the girl reveal is pink and the boy reveal stays teal
- reset the overlay tint to its default when no gender is specified

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d5e23ddd14832fa67c6cff732a8fed