### PR TITLE
Adjust preload priorities for essential assets

### DIFF
--- a/index.html
+++ b/index.html
@@ -1141,9 +1141,19 @@
             applyLocalizedAssets();
           }
           if (!assetPreloadPromise) {
-            assetPreloadPromise = preloadImages(ALL_IMAGE_SOURCES, "high").catch(
-              () => {},
+            const essentialSources = [
+              languageAssets.background,
+              languageAssets.tapToSpin,
+              languageAssets.instructions,
+            ].filter(Boolean);
+            const essentialSet = new Set(essentialSources);
+            const secondarySources = ALL_IMAGE_SOURCES.filter(
+              (src) => !essentialSet.has(src),
             );
+            assetPreloadPromise = Promise.all([
+              preloadImages(essentialSources, "high"),
+              preloadImages(secondarySources),
+            ]).catch(() => {});
           }
           return assetPreloadPromise;
         }


### PR DESCRIPTION
## Summary
- preload the background, tap-to-spin, and instructions art with high fetch priority
- allow secondary assets and icons to load with default priority while retaining priority-aware image creation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d5e37b66dc832fa256d7e2d1415111