### PR TITLE
Adjust landing hint button layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -90,12 +90,12 @@
         position: absolute;
         left: 50%;
         transform: translateX(-50%) scale(0.75);
-        bottom: 7.5%;
+        bottom: 4.5%;
         display: inline-flex;
         align-items: center;
         justify-content: center;
-        padding: clamp(0.35rem, 1.2vw, 0.75rem)
-          clamp(0.85rem, 3.4vw, 1.8rem);
+        padding: clamp(0.25rem, 0.9vw, 0.6rem)
+          clamp(1.15rem, 4.2vw, 2.2rem);
         border-radius: 999px;
         background: #e69c6a;
         border: clamp(3px, 1vw, 6px) solid #fff2d9;


### PR DESCRIPTION
## Summary
- lower the landing hint button so it sits closer to the bottom edge
- widen the button padding while reducing vertical padding to flatten its appearance

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d6c1e200e8832f99e4b3e03d12f386