### PR TITLE
Fix girl gender reveal overlay color

### DIFF
--- a/index.html
+++ b/index.html
@@ -1578,7 +1578,7 @@
             genderOverlay.style.background = "rgba(203, 226, 207, 0.6)";
             createConfetti(["#cbe2cf", "#ffffff", "#ffd700"]);
           } else {
-            genderOverlay.style.background = "rgba(255, 255, 255, 0.6)";
+            genderOverlay.style.background = "rgba(247, 196, 180, 0.75)";
             createConfetti([
               "#ffa98e",
               "#FFB6C1",


### PR DESCRIPTION
## Summary
- align the girl reveal overlay background with the intended pink tint used elsewhere so the overlay displays correctly during the reveal

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68d6c1ee09d4832fa432f4b53f4b21df