### PR TITLE
Adjust landing hint button size and placement

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,13 +89,13 @@
       .landing-hint {
         position: absolute;
         left: 50%;
-        transform: translateX(-75%) scale(0.75);
-        bottom: 4.5%;
+        transform: translateX(-50%) scale(0.75);
+        bottom: 2.25%;
         display: inline-flex;
         align-items: center;
         justify-content: center;
-        padding: clamp(0.25rem, 0.9vw, 0.6rem)
-          clamp(1.15rem, 4.2vw, 2.2rem);
+        padding: clamp(0.18rem, 0.65vw, 0.45rem)
+          clamp(1.75rem, 6vw, 3rem);
         border-radius: 999px;
         background: #e69c6a;
         border: clamp(3px, 1vw, 6px) solid #fff2d9;


### PR DESCRIPTION
## Summary
- lower the landing screen hint button so it sits closer to the bottom of the artwork
- widen the button by increasing its horizontal padding while reducing vertical padding
- center associated animations with the revised alignment

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_b_68dac2be4a80832f82308164983836b5