### PR TITLE
Improve landing screen asset handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,7 +79,7 @@
         left: 0;
         width: 100%;
         height: 100%;
-        background-image: url("img/Assets/babyjackpot.png");
+        background-color: #f4efe8;
         background-size: cover;
         background-position: center;
         z-index: 20;
@@ -856,6 +856,7 @@
 
       const LANGUAGE_ASSET_MAP = {
         en: {
+          landing: "img/Assets/babyjackpot.png",
           background: "img/Assets/background.png",
           tapToSpin: "img/Assets/taptospin.png",
           instructions: "img/Assets/instructions.png",
@@ -863,6 +864,7 @@
           girlIcon: "img/Assets/girl.png",
         },
         es: {
+          landing: "img/Assets/Spanish/babyjackpot-spanish.png",
           background: "img/Assets/Spanish/background-spanish.png",
           tapToSpin: "img/Assets/Spanish/taptospin-spanish.png",
           instructions: "img/Assets/Spanish/instructions-spanish.png",
@@ -870,6 +872,7 @@
           girlIcon: "img/Assets/Spanish/girl-spanish.png",
         },
         fr: {
+          landing: "img/Assets/French/babyjackpot-french.png",
           background: "img/Assets/French/background-french.png",
           tapToSpin: "img/Assets/French/taptospin-french.png",
           instructions: "img/Assets/French/instructions-french.png",
@@ -877,6 +880,7 @@
           girlIcon: "img/Assets/French/girl-french.png",
         },
         de: {
+          landing: "img/Assets/German/babyjackpot-german.png",
           background: "img/Assets/German/background-german.png",
           tapToSpin: "img/Assets/German/taptospin-german.png",
           instructions: "img/Assets/German/instructions-german.png",
@@ -914,6 +918,7 @@
       const englishAssets = LANGUAGE_ASSET_MAP.en;
       const ICON_SOURCES = buildIconSources(languageAssets);
       const CRITICAL_IMAGE_SOURCES = [
+        languageAssets.landing,
         languageAssets.background,
         languageAssets.tapToSpin,
         languageAssets.instructions,
@@ -925,6 +930,7 @@
       );
       const FALLBACK_IMAGE_MAP = new Map();
       [
+        "landing",
         "background",
         "tapToSpin",
         "instructions",
@@ -1181,6 +1187,7 @@
           }
           if (!assetPreloadPromise) {
             const essentialSources = [
+              languageAssets.landing,
               languageAssets.background,
               languageAssets.tapToSpin,
               languageAssets.instructions,
@@ -1196,20 +1203,24 @@
           }
           return assetPreloadPromise;
         }
-        const landingBackgrounds = {
-          es: "img/Assets/Spanish/babyjackpot-spanish.png",
-          fr: "img/Assets/French/babyjackpot-french.png",
-          de: "img/Assets/German/babyjackpot-german.png",
-        };
         const landingScreen = document.getElementById("landing-screen");
         const landingHint = document.getElementById("landingHint");
         let landingHintTimeout = null;
         let refitIntroText = null;
         if (landingScreen) {
-          const landingImage =
-            landingBackgrounds[normalizedLanguage] ||
-            "img/Assets/babyjackpot.png";
-          landingScreen.style.backgroundImage = `url("${landingImage}")`;
+          const landingImage = languageAssets.landing || englishAssets.landing;
+          const applyLandingBackground = () => {
+            if (!landingImage) {
+              return;
+            }
+            const cached = imageCache.get(landingImage);
+            const finalSrc =
+              cached && cached.img
+                ? cached.img.currentSrc || cached.img.src || landingImage
+                : landingImage;
+            landingScreen.style.backgroundImage = `url("${finalSrc}")`;
+          };
+          applyLandingBackground();
           refitIntroText = applyIntroTextFromURL();
           if (landingHint) {
             landingHint.textContent = getHintText(normalizedLanguage);
@@ -1221,13 +1232,16 @@
               landingHint.classList.add("show");
             }, 1000);
           }
-          const landingBgImage = new Image();
-          landingBgImage.addEventListener("load", () => {
-            if (typeof refitIntroText === "function") {
-              refitIntroText();
-            }
-          });
-          landingBgImage.src = landingImage;
+          if (landingImage) {
+            loadImage(landingImage, "high")
+              .then(() => {
+                applyLandingBackground();
+                if (typeof refitIntroText === "function") {
+                  refitIntroText();
+                }
+              })
+              .catch(() => {});
+          }
           const dismissLanding = (event) => {
             if (event) {
               event.preventDefault();


### PR DESCRIPTION
## Summary
- add landing artwork paths to each locale configuration and preload/fallback handling
- load the landing background through the shared image loader instead of bespoke logic
- default the landing screen to a neutral background color until the localized art is applied

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68daca508240832f8244d92ffc2052b4