### PR TITLE
Add language selector landing page and localized form

### DIFF
--- a/form.html
+++ b/form.html
@@ -1,0 +1,387 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Customize Your Reveal Link</title>
+    <style>
+      :root {
+        color-scheme: light;
+        font-family: 'Poppins', system-ui, -apple-system, BlinkMacSystemFont,
+          'Segoe UI', sans-serif;
+        --accent: #5a5df0;
+      }
+      *,
+      *::before,
+      *::after {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        min-height: 100vh;
+        background: #f6f7fb;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        padding: clamp(1.5rem, 4vw, 3.5rem);
+      }
+      main {
+        width: min(1080px, 100%);
+        display: grid;
+        gap: clamp(1.75rem, 4vw, 3rem);
+        grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+        background: white;
+        padding: clamp(1.75rem, 5vw, 3.5rem);
+        border-radius: 24px;
+        box-shadow: 0 18px 48px rgba(40, 52, 98, 0.12);
+      }
+      h1 {
+        grid-column: 1 / -1;
+        margin: 0;
+        font-size: clamp(1.85rem, 4vw, 2.75rem);
+        font-weight: 600;
+        color: #1f2345;
+        text-align: center;
+      }
+      form {
+        display: flex;
+        flex-direction: column;
+        gap: 1.5rem;
+      }
+      label {
+        display: block;
+        font-weight: 600;
+        font-size: 1rem;
+        color: #1f2345;
+        margin-bottom: 0.5rem;
+      }
+      fieldset {
+        border: none;
+        padding: 0;
+        margin: 0;
+      }
+      .radio-group {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(120px, 1fr));
+        gap: 0.75rem;
+      }
+      .radio-option {
+        display: flex;
+        align-items: center;
+        gap: 0.65rem;
+        padding: 0.8rem 1rem;
+        border-radius: 12px;
+        border: 1px solid rgba(31, 35, 69, 0.12);
+        background: #f9f9ff;
+        cursor: pointer;
+        transition: border-color 120ms ease, background 120ms ease,
+          box-shadow 120ms ease;
+      }
+      .radio-option input[type='radio'] {
+        width: 18px;
+        height: 18px;
+        accent-color: var(--accent);
+      }
+      .radio-option.active {
+        border-color: rgba(90, 93, 240, 0.65);
+        background: rgba(90, 93, 240, 0.08);
+        box-shadow: 0 10px 24px rgba(90, 93, 240, 0.18);
+      }
+      textarea {
+        width: 100%;
+        min-height: 140px;
+        border-radius: 16px;
+        border: 1px solid rgba(31, 35, 69, 0.16);
+        padding: 1rem 1.15rem;
+        font-family: inherit;
+        font-size: 1rem;
+        resize: vertical;
+        transition: border-color 120ms ease, box-shadow 120ms ease;
+      }
+      textarea:focus {
+        border-color: rgba(90, 93, 240, 0.7);
+        box-shadow: 0 0 0 4px rgba(90, 93, 240, 0.15);
+        outline: none;
+      }
+      .actions {
+        display: flex;
+        gap: 1rem;
+        flex-wrap: wrap;
+      }
+      button.primary {
+        border: none;
+        border-radius: 999px;
+        padding: 0.85rem 1.75rem;
+        font-size: 1rem;
+        font-weight: 600;
+        background: var(--accent);
+        color: white;
+        cursor: pointer;
+        transition: transform 120ms ease, box-shadow 120ms ease;
+      }
+      button.primary:hover,
+      button.primary:focus-visible {
+        transform: translateY(-2px);
+        box-shadow: 0 14px 24px rgba(90, 93, 240, 0.3);
+        outline: none;
+      }
+      .output {
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+      }
+      .output input[type='text'] {
+        width: 100%;
+        border-radius: 12px;
+        border: 1px solid rgba(31, 35, 69, 0.16);
+        padding: 0.85rem 1.15rem;
+        font-size: 0.95rem;
+      }
+      .output-controls {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.75rem;
+      }
+      button.secondary {
+        border: none;
+        border-radius: 999px;
+        padding: 0.75rem 1.5rem;
+        font-size: 0.95rem;
+        font-weight: 600;
+        background: rgba(31, 35, 69, 0.08);
+        color: #1f2345;
+        cursor: pointer;
+        transition: background 120ms ease, transform 120ms ease;
+      }
+      button.secondary:hover,
+      button.secondary:focus-visible {
+        background: rgba(31, 35, 69, 0.16);
+        transform: translateY(-1px);
+        outline: none;
+      }
+      section.preview {
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+      }
+      section.preview h2 {
+        margin: 0;
+        font-size: 1.25rem;
+        font-weight: 600;
+        color: #1f2345;
+      }
+      .preview-frame {
+        aspect-ratio: 9 / 16;
+        width: 100%;
+        border-radius: 18px;
+        border: 1px solid rgba(31, 35, 69, 0.12);
+        box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.65);
+      }
+      @media (max-width: 760px) {
+        main {
+          grid-template-columns: 1fr;
+        }
+        .actions {
+          flex-direction: column;
+          align-items: stretch;
+        }
+        .actions button {
+          width: 100%;
+          text-align: center;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1 id="formTitle">Customize Your Reveal Link</h1>
+      <form id="revealForm">
+        <fieldset>
+          <legend id="genderLabel">Boy or Girl?</legend>
+          <div class="radio-group" role="radiogroup" aria-labelledby="genderLabel">
+            <label class="radio-option active">
+              <input type="radio" name="gender" value="boy" checked />
+              <span data-gender-option="boy">Boy</span>
+            </label>
+            <label class="radio-option">
+              <input type="radio" name="gender" value="girl" />
+              <span data-gender-option="girl">Girl</span>
+            </label>
+          </div>
+        </fieldset>
+        <div>
+          <label for="message" id="messageLabel">Reveal Message</label>
+          <textarea id="message" placeholder="Reveal Message"></textarea>
+        </div>
+        <div class="actions">
+          <button type="button" class="primary" id="generateButton">
+            Generate URL
+          </button>
+        </div>
+        <div class="output">
+          <input
+            type="text"
+            id="resultUrl"
+            readonly
+            aria-live="polite"
+            value="https://genderslotreveal.netlify.app/"
+          />
+          <div class="output-controls">
+            <button type="button" class="secondary" id="copyButton">
+              Copy to Clipboard
+            </button>
+          </div>
+        </div>
+      </form>
+      <section class="preview">
+        <h2 id="previewHeading">Live Preview</h2>
+        <iframe
+          id="previewFrame"
+          class="preview-frame"
+          title="Preview"
+          loading="lazy"
+        ></iframe>
+      </section>
+    </main>
+    <script>
+      const translations = {
+        en: {
+          title: 'Customize Your Reveal Link',
+          gender: 'Boy or Girl?',
+          message: 'Reveal Message',
+          generate: 'Generate URL',
+          copy: 'Copy to Clipboard',
+          boy: 'Boy',
+          girl: 'Girl',
+        },
+        es: {
+          title: 'Personaliza tu enlace',
+          gender: '¿Niño o niña?',
+          message: 'Mensaje de revelación',
+          generate: 'Generar enlace',
+          copy: 'Copiar',
+          boy: 'Niño',
+          girl: 'Niña',
+        },
+        fr: {
+          title: 'Personnalisez votre lien',
+          gender: 'Garçon ou fille ?',
+          message: 'Message de révélation',
+          generate: 'Générer le lien',
+          copy: 'Copier',
+          boy: 'Garçon',
+          girl: 'Fille',
+        },
+        de: {
+          title: 'Passen Sie Ihren Link an',
+          gender: 'Junge oder Mädchen?',
+          message: 'Enthüllungsnachricht',
+          generate: 'Link erstellen',
+          copy: 'Kopieren',
+          boy: 'Junge',
+          girl: 'Mädchen',
+        },
+      };
+
+      const params = new URLSearchParams(window.location.search);
+      const langParam = params.get('lang') || 'en';
+      const lang = translations[langParam] ? langParam : 'en';
+      const t = translations[lang];
+
+      document.documentElement.lang = lang;
+      document.title = t.title;
+
+      const formTitle = document.getElementById('formTitle');
+      const genderLabel = document.getElementById('genderLabel');
+      const messageLabel = document.getElementById('messageLabel');
+      const messageField = document.getElementById('message');
+      const generateButton = document.getElementById('generateButton');
+      const copyButton = document.getElementById('copyButton');
+      const resultUrl = document.getElementById('resultUrl');
+      const previewFrame = document.getElementById('previewFrame');
+      const genderOptions = document.querySelectorAll('.radio-option');
+
+      formTitle.textContent = t.title;
+      genderLabel.textContent = t.gender;
+      messageLabel.textContent = t.message;
+      messageField.placeholder = t.message;
+      generateButton.textContent = t.generate;
+      copyButton.textContent = t.copy;
+      document.querySelector('[data-gender-option="boy"]').textContent = t.boy;
+      document.querySelector('[data-gender-option="girl"]').textContent = t.girl;
+
+      function b64EncodeUnicode(str) {
+        return btoa(
+          encodeURIComponent(str).replace(/%([0-9A-F]{2})/g, (_, p1) =>
+            String.fromCharCode(parseInt(p1, 16))
+          )
+        );
+      }
+
+      function buildObfuscatedUrl() {
+        const genderValue = (
+          document.querySelector('input[name="gender"]:checked') || { value: '' }
+        ).value;
+        const messageValue = messageField.value || '';
+
+        const innerParams = new URLSearchParams();
+        innerParams.set('lang', lang);
+        innerParams.set('gender', genderValue);
+        innerParams.set('message', messageValue);
+
+        const encoded = b64EncodeUnicode(innerParams.toString());
+        return `https://genderslotreveal.netlify.app/?d=${encodeURIComponent(encoded)}`;
+      }
+
+      function updatePreview() {
+        const url = buildObfuscatedUrl();
+        resultUrl.value = url;
+        previewFrame.src = url;
+      }
+
+      function setActiveRadio(targetLabel) {
+        genderOptions.forEach((option) => {
+          if (option === targetLabel) {
+            option.classList.add('active');
+          } else {
+            option.classList.remove('active');
+          }
+        });
+      }
+
+      genderOptions.forEach((label) => {
+        const input = label.querySelector('input[type="radio"]');
+        input.addEventListener('change', () => {
+          if (input.checked) {
+            setActiveRadio(label);
+            updatePreview();
+          }
+        });
+      });
+
+      messageField.addEventListener('input', () => {
+        updatePreview();
+      });
+
+      generateButton.addEventListener('click', () => {
+        updatePreview();
+      });
+
+      copyButton.addEventListener('click', async () => {
+        try {
+          const originalText = copyButton.dataset.originalText || copyButton.textContent;
+          await navigator.clipboard.writeText(resultUrl.value);
+          copyButton.dataset.originalText = originalText;
+          copyButton.textContent = `${originalText} ✓`;
+          setTimeout(() => {
+            copyButton.textContent = copyButton.dataset.originalText;
+          }, 1400);
+        } catch (error) {
+          console.error('Clipboard copy failed', error);
+        }
+      });
+
+      updatePreview();
+    </script>
+  </body>
+</html>

--- a/language.html
+++ b/language.html
@@ -1,0 +1,90 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Select Language · Gender Slot Reveal</title>
+    <style>
+      :root {
+        color-scheme: light;
+        font-family: 'Poppins', system-ui, -apple-system, BlinkMacSystemFont,
+          'Segoe UI', sans-serif;
+      }
+      *,
+      *::before,
+      *::after {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
+        background: radial-gradient(circle at top, #ffe7f1 0%, #f5f7ff 55%, #e7ecff);
+        padding: clamp(1.5rem, 4vw, 4rem);
+      }
+      h1 {
+        font-size: clamp(1.75rem, 4vw, 2.75rem);
+        font-weight: 600;
+        color: #2a2d3a;
+        text-align: center;
+        margin-bottom: clamp(1.5rem, 4vw, 3rem);
+      }
+      .language-grid {
+        width: min(720px, 100%);
+        display: grid;
+        gap: clamp(1rem, 2vw, 1.5rem);
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      }
+      button.language-choice {
+        border: none;
+        border-radius: 18px;
+        padding: clamp(1.75rem, 4vw, 2.75rem) clamp(1.5rem, 5vw, 3rem);
+        font-size: clamp(1.35rem, 3vw, 1.75rem);
+        font-weight: 600;
+        background: white;
+        color: #2a2d3a;
+        box-shadow: 0 18px 40px rgba(26, 33, 64, 0.14);
+        transition: transform 160ms ease, box-shadow 160ms ease;
+        cursor: pointer;
+      }
+      button.language-choice:hover,
+      button.language-choice:focus-visible {
+        transform: translateY(-6px);
+        box-shadow: 0 26px 50px rgba(26, 33, 64, 0.2);
+        outline: none;
+      }
+      button.language-choice:active {
+        transform: translateY(-2px);
+      }
+      @media (max-width: 520px) {
+        body {
+          padding: 1.5rem;
+        }
+        .language-grid {
+          grid-template-columns: 1fr;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Select your language</h1>
+    <div class="language-grid">
+      <button class="language-choice" data-lang="en">English</button>
+      <button class="language-choice" data-lang="es">Español</button>
+      <button class="language-choice" data-lang="fr">Français</button>
+      <button class="language-choice" data-lang="de">Deutsch</button>
+    </div>
+    <script>
+      document.querySelectorAll('.language-choice').forEach((button) => {
+        button.addEventListener('click', () => {
+          const lang = button.dataset.lang;
+          const destination = `form.html?lang=${encodeURIComponent(lang)}`;
+          window.location.href = destination;
+        });
+      });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a new landing page that lets visitors choose English, Spanish, French, or German before building a link
- create a localized form page that swaps labels and placeholders based on the selected language
- ensure generated links always use the obfuscated `?d=` parameter and keep the live preview and copy helpers in sync

## Testing
- Manual verification in browser

------
https://chatgpt.com/codex/tasks/task_b_68dacc0fcf98832f949d7d58c446bff6