### PR TITLE
Reduce landing hint footprint

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,19 +89,19 @@
       .landing-hint {
         position: absolute;
         left: 50%;
-        transform: translateX(-50%) scale(0.75);
-        bottom: 2.25%;
+        transform: translateX(-50%) scale(0.68);
+        bottom: 1.75%;
         display: inline-flex;
         align-items: center;
         justify-content: center;
-        padding: clamp(0.18rem, 0.65vw, 0.45rem)
-          clamp(1.75rem, 6vw, 3rem);
+        padding: clamp(0.16rem, 0.55vw, 0.38rem)
+          clamp(1.5rem, 5.2vw, 2.6rem);
         border-radius: 999px;
         background: #e69c6a;
         border: clamp(3px, 1vw, 6px) solid #fff2d9;
         color: #fff2d9;
         font-family: 'SparkyStones', sans-serif;
-        font-size: clamp(16px, 3vw, 24px);
+        font-size: clamp(14px, 2.6vw, 20px);
         line-height: 1.1;
         text-align: center;
         letter-spacing: 0.08em;
@@ -109,7 +109,7 @@
         text-shadow: 0 2px 0 rgba(159, 83, 36, 0.85);
         box-shadow: 0 6px 0 rgba(159, 83, 36, 0.55),
           0 10px 16px rgba(0, 0, 0, 0.16);
-        max-width: min(86%, 320px);
+        max-width: min(78%, 280px);
         opacity: 0;
         pointer-events: none;
       }
@@ -123,22 +123,22 @@
       @keyframes hint-fade-in {
         from {
           opacity: 0;
-          transform: translateX(-50%) translateY(4px) scale(0.75);
+          transform: translateX(-50%) translateY(4px) scale(0.68);
         }
         to {
           opacity: 1;
-          transform: translateX(-50%) translateY(0) scale(0.75);
+          transform: translateX(-50%) translateY(0) scale(0.68);
         }
       }
 
       @keyframes hint-pulse {
         from {
-          transform: translateX(-50%) translateY(0) scale(0.75);
+          transform: translateX(-50%) translateY(0) scale(0.68);
           box-shadow: 0 6px 0 rgba(159, 83, 36, 0.55),
             0 10px 16px rgba(0, 0, 0, 0.16);
         }
         to {
-          transform: translateX(-50%) translateY(0) scale(0.77);
+          transform: translateX(-50%) translateY(0) scale(0.7);
           box-shadow: 0 8px 0 rgba(159, 83, 36, 0.6),
             0 14px 22px rgba(0, 0, 0, 0.2);
         }


### PR DESCRIPTION
## Summary
- shrink the landing hint button padding, font size, and scale so it no longer overlaps marquee text in wider translations
- adjust animation transforms to match the new base scale

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e3ef454ad0832fad33a048081ce9a7